### PR TITLE
Start fixing Glk banner colours: don't use measured colours (#3)

### DIFF
--- a/glk/osglk.c
+++ b/glk/osglk.c
@@ -43,13 +43,6 @@ static int curattr = 0;
 winid_t mainwin;
 winid_t statuswin;
 
-glui32 mainfg;
-glui32 mainbg;
-
-glui32 statusfg;
-glui32 statusbg;
-
-
 /* ------------------------------------------------------------------------ */
 /*
  *   Get system information.  'code' is a SYSINFO_xxx code, which
@@ -145,29 +138,6 @@ int os_init(int *argc, char *argv[], const char *prompt,
         fprintf(stderr, "fatal: could not open window!\n");
         glk_exit();
     }
-
-    /* get default colors for main window */
-    if (!glk_style_measure(mainwin, style_Normal, stylehint_TextColor, &mainfg))
-        mainfg = 0;
-
-    if (!glk_style_measure(mainwin, style_Normal, stylehint_BackColor, &mainbg))
-        mainbg = 0;
-
-    /* get default colors for status window */
-    statuswin = glk_window_open(mainwin,
-            winmethod_Above | winmethod_Fixed, 1,
-            wintype_TextGrid, 0);
-
-    if (!glk_style_measure(statuswin, style_Normal, stylehint_TextColor, &statusfg))
-        statusfg = 0;
-
-    if (!glk_style_measure(statuswin, style_Normal, stylehint_BackColor, &statusbg))
-        statusbg = 0;
-
-    /* close statuswin; reopened on request */
-    glk_window_close(statuswin, 0);
-
-    statuswin = NULL;
 
     glk_set_window(mainwin);
 


### PR DESCRIPTION
Started fixing #3.

I've removed the mainfg/bg colours as we don't need them.

`os_banner_set_screen_color` doesn't do anything now, so need to work out a better solution for it. Anyone got an example story that uses it?