### PR TITLE
Change #include <os.h> to #include "os.h"

### DIFF
--- a/tads3/gameinfl.cpp
+++ b/tads3/gameinfl.cpp
@@ -21,7 +21,7 @@ Modified
 #include <string.h>
 #include <stdlib.h>
 
-#include <os.h>
+#include "os.h"
 #include "t3std.h"
 #include "utf8.h"
 #include "vmerr.h"

--- a/tads3/gameinfo.cpp
+++ b/tads3/gameinfo.cpp
@@ -39,7 +39,7 @@ Modified
 #include <string.h>
 #include <stdlib.h>
 
-#include <os.h>
+#include "os.h"
 #include "t3std.h"
 #include "utf8.h"
 

--- a/tads3/resfind.cpp
+++ b/tads3/resfind.cpp
@@ -25,7 +25,7 @@ Modified
 #include <string.h>
 #include <stdlib.h>
 
-#include <os.h>
+#include "os.h"
 #include "t3std.h"
 #include "resfind.h"
 

--- a/tads3/vmbignum.h
+++ b/tads3/vmbignum.h
@@ -21,7 +21,7 @@ Modified
 #define VMBIGNUM_H
 
 #include <stdlib.h>
-#include <os.h>
+#include "os.h"
 #include "vmtype.h"
 #include "vmobj.h"
 #include "vmglob.h"

--- a/tads3/vmpat.cpp
+++ b/tads3/vmpat.cpp
@@ -16,7 +16,7 @@ Modified
 */
 
 #include <stdlib.h>
-#include <os.h>
+#include "os.h"
 #include "vmtype.h"
 #include "vmobj.h"
 #include "vmmeta.h"

--- a/tads3/vmpat.h
+++ b/tads3/vmpat.h
@@ -23,7 +23,7 @@ Modified
 #define VMPAT_H
 
 #include <stdlib.h>
-#include <os.h>
+#include "os.h"
 #include "vmtype.h"
 #include "vmobj.h"
 #include "vmglob.h"

--- a/tads3/vmstrcmp.cpp
+++ b/tads3/vmstrcmp.cpp
@@ -17,7 +17,7 @@ Modified
 
 
 #include <stdlib.h>
-#include <os.h>
+#include "os.h"
 #include "utf8.h"
 #include "vmuni.h"
 #include "vmtype.h"

--- a/tads3/vmstrcmp.h
+++ b/tads3/vmstrcmp.h
@@ -44,7 +44,7 @@ Modified
 #define VMSTRCMP_H
 
 #include <stdlib.h>
-#include <os.h>
+#include "os.h"
 #include "vmtype.h"
 #include "vmobj.h"
 #include "vmglob.h"


### PR DESCRIPTION
This is really more of a question than a pull request.

I don't understand why you'd want to include `os.h` as a system header. Either you would have to copy it from the tads2 folder to the system header folder, or instruct the compiler to look for system headers in the tads2 folder, both of which seem strange to me.

This PR leaves the ` #include <os.h>`in `/tads2/msdos/ltkwin.c` alone, simply because I understand even less about MS-DOS.
