### PR TITLE
Fix building on musl libc

### DIFF
--- a/tads3/sha2.cpp
+++ b/tads3/sha2.cpp
@@ -113,8 +113,6 @@
 #  include <stdlib.h>
 #  if !defined (_ENDIAN_H)
 #    include <sys/param.h>
-#  else
-#    include _ENDIAN_H
 #  endif
 #elif defined(GARGOYLE)
 #    include <sys/param.h>


### PR DESCRIPTION
At least on musl and glibc, _ENDIAN_H is just the name of an include
guard. I'm not sure why it's being passed to #include, or what the
original intent was. But including _ENDIAN_H doesn't make sense in these
cases: it will either evaluate to:

    #include 1

or

    #include

Neither of which makes any sense. If the tests get this far and
_ENDIAN_H exists, it's at least reasonable to assume the various
endian-related macros will exist. This does allow musl libc to
successfully build TADS.

A better solution, in my opinion, would be to replace this SHA-256
implementation with an endian-neutral one. It'd likely be a bit slower,
but that's almost surely not very important here. But this clearly
hasn't been an issue on most TADS-targeted platforms, so it's probably
not worth making a high priority.

As a note, musl libc intentionally avoids defining a __MUSL__ or similar
macro, so it can't be detected the way that glibc is.