### PR TITLE
Support both garglk_fileref_get_name() and glkunix_fileref_get_filename()

### DIFF
--- a/glk/osgarglk.h
+++ b/glk/osgarglk.h
@@ -89,17 +89,15 @@ unsigned char *os_fill_buffer (unsigned char *buf, size_t len);
 
 int os_vasprintf(char **bufptr, const char *fmt, va_list ap);
 
-// Patch Remglk's fileref_get_filename function
+// Support both the old garglk_fileref_get_name() and the new
+// glkunix_fileref_get_filename() functions.
 #include "glk.h"
 #include "glkstart.h"
-#ifdef GLKUNIX_FILEREF_GET_FILENAME
 
-#include "remglk.h"
-#define GLK_MODULE_FILEREF_GET_NAME
-extern char *glkunix_fileref_get_filename(frefid_t fref);
-#define garglk_fileref_get_name glkunix_fileref_get_filename
-
-#endif /* GLKUNIX_FILEREF_GET_FILENAME */
+#if defined(GLK_MODULE_FILEREF_GET_NAME) && !defined(GLKUNIX_FILEREF_GET_FILENAME)
+#define glkunix_fileref_get_filename garglk_fileref_get_name
+#define GLKUNIX_FILEREF_GET_FILENAME
+#endif
 
 #ifdef __cplusplus
 }

--- a/glk/osglk.c
+++ b/glk/osglk.c
@@ -517,12 +517,11 @@ void os_more_prompt()
 int os_askfile(const char *prompt, char *fname_buf, int fname_buf_len,
                int prompt_type, os_filetype_t file_type)
 {
+#ifndef GLKUNIX_FILEREF_GET_FILENAME
+    return OS_AFE_FAILURE;
+#else
     frefid_t fileref;
     glui32 gprompt, gusage;
-
-#ifndef GLK_MODULE_FILEREF_GET_NAME
-    return OS_AFE_FAILURE;
-#endif
 
     if (prompt_type == OS_AFP_OPEN)
         gprompt = filemode_Read;
@@ -540,11 +539,12 @@ int os_askfile(const char *prompt, char *fname_buf, int fname_buf_len,
     if (fileref == NULL)
         return OS_AFE_CANCEL;
 
-    strcpy(fname_buf, garglk_fileref_get_name(fileref));
+    strcpy(fname_buf, glkunix_fileref_get_filename(fileref));
 
     glk_fileref_destroy(fileref);
 
     return OS_AFE_SUCCESS;
+#endif
 }
 
 /* 


### PR DESCRIPTION
See garglk/garglk#631.

The gist here is that in the original code, if `GLKUNIX_FILEREF_GET_FILENAME` is defined, then `remglk.h` is included; but this file exists only in remglk. When other Glk implementations add support for `GLKUNIX_FILEREF_GET_FILENAME`, this will fail to build (or, since this is `osgarglk.c` specifically, when Gargoyle adds such support, it fails to build).

So this is my proposed fix: always use the new glkunix name, but if the new function doesn't exist, and the old one does, add a macro to point the new name to the old name.  This should work on older Gargoyles as well as newer ones which (will) support `GLKUNIX_FILEREF_GET_FILENAME`.