### PR TITLE
Switch to limtomcrypt's SHA256 implementation

### DIFF
--- a/tads3/sha2.cpp
+++ b/tads3/sha2.cpp
@@ -15,7 +15,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "sha256.h"
+#include "sha2.h"
 
 #define LTC_SHA256
 

--- a/tads3/sha2.cpp
+++ b/tads3/sha2.cpp
@@ -1,699 +1,394 @@
-/*
- ---------------------------------------------------------------------------
- Copyright (c) 2002, Dr Brian Gladman <brg@gladman.me.uk>, Worcester, UK.
- All rights reserved.
+/* From libtomcrypt 1.18.2 */
 
- LICENSE TERMS
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+#if 0
+#include "tomcrypt_private.h"
+#endif
 
- The free distribution and use of this software in both source and binary 
- form is allowed (with or without changes) provided that:
-
-   1. distributions of this source code include the above copyright 
-      notice, this list of conditions and the following disclaimer;
-
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products 
-      built using this software without specific written permission. 
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
- 
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness 
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 30/11/2002
-
- This is a byte oriented version of SHA2 that operates on arrays of bytes
- stored in memory. This code implements sha256, sha384 and sha512 but the
- latter two functions rely on efficient 64-bit integer operations that 
- may not be very efficient on 32-bit machines
-
- The sha256 functions use a type 'sha256_ctx' to hold details of the 
- current hash state and uses the following three calls:
-
-       void sha256_begin(sha256_ctx ctx[1])
-       void sha256_hash(const unsigned char data[], 
-                            unsigned long len, sha256_ctx ctx[1])
-       void sha256_end(unsigned char hval[], sha256_ctx ctx[1])
-
- The first subroutine initialises a hash computation by setting up the 
- context in the sha256_ctx context. The second subroutine hashes 8-bit 
- bytes from array data[] into the hash state withinh sha256_ctx context, 
- the number of bytes to be hashed being given by the the unsigned long 
- integer len.  The third subroutine completes the hash calculation and 
- places the resulting digest value in the array of 8-bit bytes hval[].
-
- The sha384 and sha512 functions are similar and use the interfaces:
-
-       void sha384_begin(sha384_ctx ctx[1]);
-       void sha384_hash(const unsigned char data[], 
-                            unsigned long len, sha384_ctx ctx[1]);
-       void sha384_end(unsigned char hval[], sha384_ctx ctx[1]);
-
-       void sha512_begin(sha512_ctx ctx[1]);
-       void sha512_hash(const unsigned char data[], 
-                            unsigned long len, sha512_ctx ctx[1]);
-       void sha512_end(unsigned char hval[], sha512_ctx ctx[1]);
-
- In addition there is a function sha2 that can be used to call all these
- functions using a call with a hash length parameter as follows:
-
-       int sha2_begin(unsigned long len, sha2_ctx ctx[1]);
-       void sha2_hash(const unsigned char data[], 
-                            unsigned long len, sha2_ctx ctx[1]);
-       void sha2_end(unsigned char hval[], sha2_ctx ctx[1]);
-
- My thanks to Erik Andersen <andersen@codepoet.org> for testing this code 
- on big-endian systems and for his assistance with corrections
+/**
+  @file sha256.c
+  LTC_SHA256 by Tom St Denis
 */
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-/* define the hash functions that you need          */
+#include "sha256.h"
 
-//#define SHA_2           /* for dynamic hash length  */  // $$$MJR - removed
-#define SHA_256
-//#define SHA_384  // $$$MJR - removed
-//#define SHA_512  // $$$MJR - removed
+#define LTC_SHA256
 
-#include <string.h>     /* for memcpy() etc.        */
-#include <stdlib.h>     /* for _lrotr with VC++     */
-#include <stdarg.h>
+#define MIN(x, y) ( ((x)<(y))?(x):(y) )
+#define XMEMCPY memcpy
+#define XSTRLEN strlen
 
-#include "sha2.h"
-#include "t3std.h"
-#include "vmdatasrc.h"
+#define STORE32H(x, y)                                                                     \
+  do { (y)[0] = (unsigned char)(((x)>>24)&255); (y)[1] = (unsigned char)(((x)>>16)&255);   \
+       (y)[2] = (unsigned char)(((x)>>8)&255); (y)[3] = (unsigned char)((x)&255); } while(0)
 
-/*  1. PLATFORM SPECIFIC INCLUDES */
+#define STORE64H(x, y)                                                                     \
+do { (y)[0] = (unsigned char)(((x)>>56)&255); (y)[1] = (unsigned char)(((x)>>48)&255);     \
+     (y)[2] = (unsigned char)(((x)>>40)&255); (y)[3] = (unsigned char)(((x)>>32)&255);     \
+     (y)[4] = (unsigned char)(((x)>>24)&255); (y)[5] = (unsigned char)(((x)>>16)&255);     \
+     (y)[6] = (unsigned char)(((x)>>8)&255); (y)[7] = (unsigned char)((x)&255); } while(0)
 
-#if defined(__GNU_LIBRARY__)
-#  include <byteswap.h>
-#  include <endian.h>
-#elif defined(__CRYPTLIB__)
-#  if defined( INC_ALL )
-#    include "crypt.h"
-#  elif defined( INC_CHILD )
-#    include "../crypt.h"
-#  else
-#    include "crypt.h"
-#  endif
-#  if defined(DATA_LITTLEENDIAN)
-#    define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#  else
-#    define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#  endif
-#elif defined(_MSC_VER)
-#  include <stdlib.h>
-#elif !defined(WIN32)
-#  include <stdlib.h>
-#  if !defined (_ENDIAN_H)
-#    include <sys/param.h>
-#  endif
-#elif defined(GARGOYLE)
-#    include <sys/param.h>
+typedef uint32_t ulong32;
+
+#define LOAD32H(x, y)                            \
+  do { x = ((ulong32)((y)[0] & 255)<<24) | \
+           ((ulong32)((y)[1] & 255)<<16) | \
+           ((ulong32)((y)[2] & 255)<<8)  | \
+           ((ulong32)((y)[3] & 255)); } while(0)
+
+#define RORc(x, y) ( ((((ulong32)(x)&0xFFFFFFFFUL)>>(ulong32)((y)&31)) | ((ulong32)(x)<<(ulong32)((32-((y)&31))&31))) & 0xFFFFFFFFUL)
+
+#define LTC_ARGCHK(x) assert(x)
+
+#define HASH_PROCESS(func_name, compress_name, state_var, block_size)                       \
+int func_name (hash_state * md, const unsigned char *in, unsigned long inlen)               \
+{                                                                                           \
+    unsigned long n;                                                                        \
+    int           err;                                                                      \
+    LTC_ARGCHK(md != NULL);                                                                 \
+    LTC_ARGCHK(in != NULL);                                                                 \
+    if (md-> state_var .curlen > sizeof(md-> state_var .buf)) {                             \
+       return CRYPT_INVALID_ARG;                                                            \
+    }                                                                                       \
+    if ((md-> state_var .length + inlen) < md-> state_var .length) {                        \
+      return CRYPT_HASH_OVERFLOW;                                                           \
+    }                                                                                       \
+    while (inlen > 0) {                                                                     \
+        if (md-> state_var .curlen == 0 && inlen >= block_size) {                           \
+           if ((err = compress_name (md, (unsigned char *)in)) != CRYPT_OK) {               \
+              return err;                                                                   \
+           }                                                                                \
+           md-> state_var .length += block_size * 8;                                        \
+           in             += block_size;                                                    \
+           inlen          -= block_size;                                                    \
+        } else {                                                                            \
+           n = MIN(inlen, (block_size - md-> state_var .curlen));                           \
+           XMEMCPY(md-> state_var .buf + md-> state_var.curlen, in, (size_t)n);             \
+           md-> state_var .curlen += n;                                                     \
+           in             += n;                                                             \
+           inlen          -= n;                                                             \
+           if (md-> state_var .curlen == block_size) {                                      \
+              if ((err = compress_name (md, md-> state_var .buf)) != CRYPT_OK) {            \
+                 return err;                                                                \
+              }                                                                             \
+              md-> state_var .length += 8*block_size;                                       \
+              md-> state_var .curlen = 0;                                                   \
+           }                                                                                \
+       }                                                                                    \
+    }                                                                                       \
+    return CRYPT_OK;                                                                        \
+}
+
+#ifdef LTC_SHA256
+
+#ifdef LTC_SMALL_CODE
+/* the K array */
+static const ulong32 K[64] = {
+    0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL, 0x3956c25bUL,
+    0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL, 0xd807aa98UL, 0x12835b01UL,
+    0x243185beUL, 0x550c7dc3UL, 0x72be5d74UL, 0x80deb1feUL, 0x9bdc06a7UL,
+    0xc19bf174UL, 0xe49b69c1UL, 0xefbe4786UL, 0x0fc19dc6UL, 0x240ca1ccUL,
+    0x2de92c6fUL, 0x4a7484aaUL, 0x5cb0a9dcUL, 0x76f988daUL, 0x983e5152UL,
+    0xa831c66dUL, 0xb00327c8UL, 0xbf597fc7UL, 0xc6e00bf3UL, 0xd5a79147UL,
+    0x06ca6351UL, 0x14292967UL, 0x27b70a85UL, 0x2e1b2138UL, 0x4d2c6dfcUL,
+    0x53380d13UL, 0x650a7354UL, 0x766a0abbUL, 0x81c2c92eUL, 0x92722c85UL,
+    0xa2bfe8a1UL, 0xa81a664bUL, 0xc24b8b70UL, 0xc76c51a3UL, 0xd192e819UL,
+    0xd6990624UL, 0xf40e3585UL, 0x106aa070UL, 0x19a4c116UL, 0x1e376c08UL,
+    0x2748774cUL, 0x34b0bcb5UL, 0x391c0cb3UL, 0x4ed8aa4aUL, 0x5b9cca4fUL,
+    0x682e6ff3UL, 0x748f82eeUL, 0x78a5636fUL, 0x84c87814UL, 0x8cc70208UL,
+    0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL
+};
 #endif
 
-/*  2. BYTE ORDER IN 32-BIT WORDS
+/* Various logical functions */
+#define Ch(x,y,z)       (z ^ (x & (y ^ z)))
+#define Maj(x,y,z)      (((x | y) & z) | (x & y))
+#define S(x, n)         RORc((x),(n))
+#define R(x, n)         (((x)&0xFFFFFFFFUL)>>(n))
+#define Sigma0(x)       (S(x, 2) ^ S(x, 13) ^ S(x, 22))
+#define Sigma1(x)       (S(x, 6) ^ S(x, 11) ^ S(x, 25))
+#define Gamma0(x)       (S(x, 7) ^ S(x, 18) ^ R(x, 3))
+#define Gamma1(x)       (S(x, 17) ^ S(x, 19) ^ R(x, 10))
 
-    To obtain the highest speed on processors with 32-bit words, this code 
-    needs to determine the order in which bytes are packed into such words.
-    The following block of code is an attempt to capture the most obvious 
-    ways in which various environemnts specify their endian definitions. 
-    It may well fail, in which case the definitions will need to be set by 
-    editing at the points marked **** EDIT HERE IF NECESSARY **** below.
+/* compress 512-bits */
+#ifdef LTC_CLEAN_STACK
+static int ss_sha256_compress(hash_state * md, const unsigned char *buf)
+#else
+static int s_sha256_compress(hash_state * md, const unsigned char *buf)
+#endif
+{
+    ulong32 S[8], W[64], t0, t1;
+#ifdef LTC_SMALL_CODE
+    ulong32 t;
+#endif
+    int i;
+
+    /* copy state into S */
+    for (i = 0; i < 8; i++) {
+        S[i] = md->sha256.state[i];
+    }
+
+    /* copy the state into 512-bits into W[0..15] */
+    for (i = 0; i < 16; i++) {
+        LOAD32H(W[i], buf + (4*i));
+    }
+
+    /* fill W[16..63] */
+    for (i = 16; i < 64; i++) {
+        W[i] = Gamma1(W[i - 2]) + W[i - 7] + Gamma0(W[i - 15]) + W[i - 16];
+    }
+
+    /* Compress */
+#ifdef LTC_SMALL_CODE
+#define RND(a,b,c,d,e,f,g,h,i)                         \
+     t0 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];   \
+     t1 = Sigma0(a) + Maj(a, b, c);                    \
+     d += t0;                                          \
+     h  = t0 + t1;
+
+     for (i = 0; i < 64; ++i) {
+         RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],i);
+         t = S[7]; S[7] = S[6]; S[6] = S[5]; S[5] = S[4];
+         S[4] = S[3]; S[3] = S[2]; S[2] = S[1]; S[1] = S[0]; S[0] = t;
+     }
+#else
+#define RND(a,b,c,d,e,f,g,h,i,ki)                    \
+     t0 = h + Sigma1(e) + Ch(e, f, g) + ki + W[i];   \
+     t1 = Sigma0(a) + Maj(a, b, c);                  \
+     d += t0;                                        \
+     h  = t0 + t1;
+
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],0,0x428a2f98);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],1,0x71374491);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],2,0xb5c0fbcf);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],3,0xe9b5dba5);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],4,0x3956c25b);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],5,0x59f111f1);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],6,0x923f82a4);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],7,0xab1c5ed5);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],8,0xd807aa98);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],9,0x12835b01);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],10,0x243185be);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],11,0x550c7dc3);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],12,0x72be5d74);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],13,0x80deb1fe);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],14,0x9bdc06a7);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],15,0xc19bf174);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],16,0xe49b69c1);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],17,0xefbe4786);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],18,0x0fc19dc6);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],19,0x240ca1cc);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],20,0x2de92c6f);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],21,0x4a7484aa);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],22,0x5cb0a9dc);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],23,0x76f988da);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],24,0x983e5152);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],25,0xa831c66d);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],26,0xb00327c8);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],27,0xbf597fc7);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],28,0xc6e00bf3);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],29,0xd5a79147);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],30,0x06ca6351);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],31,0x14292967);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],32,0x27b70a85);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],33,0x2e1b2138);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],34,0x4d2c6dfc);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],35,0x53380d13);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],36,0x650a7354);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],37,0x766a0abb);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],38,0x81c2c92e);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],39,0x92722c85);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],40,0xa2bfe8a1);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],41,0xa81a664b);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],42,0xc24b8b70);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],43,0xc76c51a3);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],44,0xd192e819);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],45,0xd6990624);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],46,0xf40e3585);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],47,0x106aa070);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],48,0x19a4c116);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],49,0x1e376c08);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],50,0x2748774c);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],51,0x34b0bcb5);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],52,0x391c0cb3);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],53,0x4ed8aa4a);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],54,0x5b9cca4f);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],55,0x682e6ff3);
+    RND(S[0],S[1],S[2],S[3],S[4],S[5],S[6],S[7],56,0x748f82ee);
+    RND(S[7],S[0],S[1],S[2],S[3],S[4],S[5],S[6],57,0x78a5636f);
+    RND(S[6],S[7],S[0],S[1],S[2],S[3],S[4],S[5],58,0x84c87814);
+    RND(S[5],S[6],S[7],S[0],S[1],S[2],S[3],S[4],59,0x8cc70208);
+    RND(S[4],S[5],S[6],S[7],S[0],S[1],S[2],S[3],60,0x90befffa);
+    RND(S[3],S[4],S[5],S[6],S[7],S[0],S[1],S[2],61,0xa4506ceb);
+    RND(S[2],S[3],S[4],S[5],S[6],S[7],S[0],S[1],62,0xbef9a3f7);
+    RND(S[1],S[2],S[3],S[4],S[5],S[6],S[7],S[0],63,0xc67178f2);
+#endif
+#undef RND
+
+    /* feedback */
+    for (i = 0; i < 8; i++) {
+        md->sha256.state[i] = md->sha256.state[i] + S[i];
+    }
+    return CRYPT_OK;
+}
+
+#ifdef LTC_CLEAN_STACK
+static int s_sha256_compress(hash_state * md, const unsigned char *buf)
+{
+    int err;
+    err = ss_sha256_compress(md, buf);
+    burn_stack(sizeof(ulong32) * 74);
+    return err;
+}
+#endif
+
+/**
+   Initialize the hash state
+   @param md   The hash state you wish to initialize
+   @return CRYPT_OK if successful
 */
-#define SHA_LITTLE_ENDIAN   1234 /* byte 0 is least significant (i386) */
-#define SHA_BIG_ENDIAN      4321 /* byte 0 is most significant (mc68k) */
-
-#if defined(CPU_IS_BIGENDIAN)
-#  if (CPU_IS_BIGENDIAN == 1)
-#    define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#  elif (CPU_IS_BIGENDIAN == 0)
-#    define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#  endif
-#endif
-
-#if !defined(PLATFORM_BYTE_ORDER)
-#if defined(LITTLE_ENDIAN) || defined(BIG_ENDIAN)
-#  if defined(LITTLE_ENDIAN) && defined(BIG_ENDIAN)
-#    if defined(BYTE_ORDER)
-#      if   (BYTE_ORDER == LITTLE_ENDIAN)
-#        define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#      elif (BYTE_ORDER == BIG_ENDIAN)
-#        define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#      endif
-#    endif
-#  elif defined(LITTLE_ENDIAN) && !defined(BIG_ENDIAN) 
-#    define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#  elif !defined(LITTLE_ENDIAN) && defined(BIG_ENDIAN)
-#    define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#  endif
-#elif defined(_LITTLE_ENDIAN) || defined(_BIG_ENDIAN)
-#  if defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)
-#    if defined(_BYTE_ORDER)
-#      if   (_BYTE_ORDER == _LITTLE_ENDIAN)
-#        define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#      elif (_BYTE_ORDER == _BIG_ENDIAN)
-#        define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#      endif
-#    endif
-#  elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN) 
-#    define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#  elif !defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)
-#    define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#  endif
-#elif 0     /* **** EDIT HERE IF NECESSARY **** */
-#define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#elif 0     /* **** EDIT HERE IF NECESSARY **** */
-#define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#elif (('1234' >> 24) == '1')
-#  define PLATFORM_BYTE_ORDER SHA_LITTLE_ENDIAN
-#elif (('4321' >> 24) == '1')
-#  define PLATFORM_BYTE_ORDER SHA_BIG_ENDIAN
-#endif
-#endif
-
-#if !defined(PLATFORM_BYTE_ORDER)
-#  error Please set undetermined byte order (lines 159 or 161 of sha2.c).
-#endif
-
-#ifdef _MSC_VER
-#pragma intrinsic(memcpy)
-#endif
-
-#define rotr32(x,n)   (((x) >> n) | ((x) << (32 - n)))
-
-#if !defined(bswap_32)
-#define bswap_32(x) (rotr32((x), 24) & 0x00ff00ff | rotr32((x), 8) & 0xff00ff00)
-#endif
-
-#if (PLATFORM_BYTE_ORDER == SHA_LITTLE_ENDIAN)
-#define SWAP_BYTES
-#else
-#undef  SWAP_BYTES
-#endif
-
-#if defined(SHA_2) || defined(SHA_256)
-
-#define SHA256_MASK (SHA256_BLOCK_SIZE - 1)
-
-#if defined(SWAP_BYTES)
-#define bsw_32(p,n)     { int _i = (n); while(_i--) p[_i] = bswap_32(p[_i]); }
-#else
-#define bsw_32(p,n)     
-#endif
-
-/* SHA256 mixing function definitions   */
-
-#define ch(x,y,z)   (((x) & (y)) ^ (~(x) & (z)))
-#define maj(x,y,z)  (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
-
-#define s256_0(x) (rotr32((x),  2) ^ rotr32((x), 13) ^ rotr32((x), 22)) 
-#define s256_1(x) (rotr32((x),  6) ^ rotr32((x), 11) ^ rotr32((x), 25)) 
-#define g256_0(x) (rotr32((x),  7) ^ rotr32((x), 18) ^ ((x) >>  3)) 
-#define g256_1(x) (rotr32((x), 17) ^ rotr32((x), 19) ^ ((x) >> 10)) 
-
-/* rotated SHA256 round definition. Rather than swapping variables as in    */
-/* FIPS-180, different variables are 'rotated' on each round, returning     */
-/* to their starting positions every eight rounds                           */
-
-#define h2(i) ctx->wbuf[i & 15] += \
-    g256_1(ctx->wbuf[(i + 14) & 15]) + ctx->wbuf[(i + 9) & 15] + g256_0(ctx->wbuf[(i + 1) & 15])
-
-#define h2_cycle(i,j)  \
-    v[(7 - i) & 7] += (j ? h2(i) : ctx->wbuf[i & 15]) + k256[i + j] \
-        + s256_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]); \
-    v[(3 - i) & 7] += v[(7 - i) & 7]; \
-    v[(7 - i) & 7] += s256_0(v[(0 - i) & 7]) + maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7])
-
-/* SHA256 mixing data   */
-
-const sha2_32t k256[64] =
-{   n_u32(428a2f98), n_u32(71374491), n_u32(b5c0fbcf), n_u32(e9b5dba5), 
-    n_u32(3956c25b), n_u32(59f111f1), n_u32(923f82a4), n_u32(ab1c5ed5), 
-    n_u32(d807aa98), n_u32(12835b01), n_u32(243185be), n_u32(550c7dc3), 
-    n_u32(72be5d74), n_u32(80deb1fe), n_u32(9bdc06a7), n_u32(c19bf174), 
-    n_u32(e49b69c1), n_u32(efbe4786), n_u32(0fc19dc6), n_u32(240ca1cc), 
-    n_u32(2de92c6f), n_u32(4a7484aa), n_u32(5cb0a9dc), n_u32(76f988da), 
-    n_u32(983e5152), n_u32(a831c66d), n_u32(b00327c8), n_u32(bf597fc7), 
-    n_u32(c6e00bf3), n_u32(d5a79147), n_u32(06ca6351), n_u32(14292967), 
-    n_u32(27b70a85), n_u32(2e1b2138), n_u32(4d2c6dfc), n_u32(53380d13), 
-    n_u32(650a7354), n_u32(766a0abb), n_u32(81c2c92e), n_u32(92722c85),
-    n_u32(a2bfe8a1), n_u32(a81a664b), n_u32(c24b8b70), n_u32(c76c51a3), 
-    n_u32(d192e819), n_u32(d6990624), n_u32(f40e3585), n_u32(106aa070), 
-    n_u32(19a4c116), n_u32(1e376c08), n_u32(2748774c), n_u32(34b0bcb5), 
-    n_u32(391c0cb3), n_u32(4ed8aa4a), n_u32(5b9cca4f), n_u32(682e6ff3), 
-    n_u32(748f82ee), n_u32(78a5636f), n_u32(84c87814), n_u32(8cc70208), 
-    n_u32(90befffa), n_u32(a4506ceb), n_u32(bef9a3f7), n_u32(c67178f2),
-};
-
-/* SHA256 initialisation data */
-
-const sha2_32t i256[8] =
+int sha256_init(hash_state * md)
 {
-    n_u32(6a09e667), n_u32(bb67ae85), n_u32(3c6ef372), n_u32(a54ff53a),
-    n_u32(510e527f), n_u32(9b05688c), n_u32(1f83d9ab), n_u32(5be0cd19)
-};
+    LTC_ARGCHK(md != NULL);
 
-void sha256_begin(sha256_ctx ctx[1])
-{
-    ctx->count[0] = ctx->count[1] = 0;
-    memcpy(ctx->hash, i256, 8 * sizeof(sha2_32t));
+    md->sha256.curlen = 0;
+    md->sha256.length = 0;
+    md->sha256.state[0] = 0x6A09E667UL;
+    md->sha256.state[1] = 0xBB67AE85UL;
+    md->sha256.state[2] = 0x3C6EF372UL;
+    md->sha256.state[3] = 0xA54FF53AUL;
+    md->sha256.state[4] = 0x510E527FUL;
+    md->sha256.state[5] = 0x9B05688CUL;
+    md->sha256.state[6] = 0x1F83D9ABUL;
+    md->sha256.state[7] = 0x5BE0CD19UL;
+    return CRYPT_OK;
 }
 
-/* Compile 64 bytes of hash data into SHA256 digest value   */
-/* NOTE: this routine assumes that the byte order in the    */
-/* ctx->wbuf[] at this point is in such an order that low   */
-/* address bytes in the ORIGINAL byte stream placed in this */
-/* buffer will now go to the high end of words on BOTH big  */
-/* and little endian systems                                */
+/**
+   Process a block of memory though the hash
+   @param md     The hash state
+   @param in     The data to hash
+   @param inlen  The length of the data (octets)
+   @return CRYPT_OK if successful
+*/
+HASH_PROCESS(sha256_process,s_sha256_compress, sha256, 64)
 
-void sha256_compile(sha256_ctx ctx[1])
-{   sha2_32t    v[8], j;
+/**
+   Terminate the hash to get the digest
+   @param md  The hash state
+   @param out [out] The destination of the hash (32 bytes)
+   @return CRYPT_OK if successful
+*/
+int sha256_done(hash_state * md, unsigned char *out)
+{
+    int i;
 
-    memcpy(v, ctx->hash, 8 * sizeof(sha2_32t));
+    LTC_ARGCHK(md  != NULL);
+    LTC_ARGCHK(out != NULL);
 
-    for(j = 0; j < 64; j += 16)
-    {
-        h2_cycle( 0, j); h2_cycle( 1, j); h2_cycle( 2, j); h2_cycle( 3, j);
-        h2_cycle( 4, j); h2_cycle( 5, j); h2_cycle( 6, j); h2_cycle( 7, j);
-        h2_cycle( 8, j); h2_cycle( 9, j); h2_cycle(10, j); h2_cycle(11, j);
-        h2_cycle(12, j); h2_cycle(13, j); h2_cycle(14, j); h2_cycle(15, j);
+    if (md->sha256.curlen >= sizeof(md->sha256.buf)) {
+       return CRYPT_INVALID_ARG;
     }
 
-    ctx->hash[0] += v[0]; ctx->hash[1] += v[1]; ctx->hash[2] += v[2]; ctx->hash[3] += v[3];
-    ctx->hash[4] += v[4]; ctx->hash[5] += v[5]; ctx->hash[6] += v[6]; ctx->hash[7] += v[7];
-}
 
-/* SHA256 hash data in an array of bytes into hash buffer   */
-/* and call the hash_compile function as required.          */
+    /* increase the length of the message */
+    md->sha256.length += md->sha256.curlen * 8;
 
-void sha256_hash(const unsigned char data[], unsigned long len, sha256_ctx ctx[1])
-{   sha2_32t pos = (sha2_32t)(ctx->count[0] & SHA256_MASK), 
-             space = SHA256_BLOCK_SIZE - pos;
-    const unsigned char *sp = data;
+    /* append the '1' bit */
+    md->sha256.buf[md->sha256.curlen++] = (unsigned char)0x80;
 
-    if((ctx->count[0] += len) < len)
-        ++(ctx->count[1]);
-
-    while(len >= space)     /* tranfer whole blocks while possible  */
-    {
-        memcpy(((unsigned char*)ctx->wbuf) + pos, sp, space);
-        sp += space; len -= space; space = SHA256_BLOCK_SIZE; pos = 0; 
-                bsw_32(ctx->wbuf, SHA256_BLOCK_SIZE >> 2)
-        sha256_compile(ctx);
+    /* if the length is currently above 56 bytes we append zeros
+     * then compress.  Then we can fall back to padding zeros and length
+     * encoding like normal.
+     */
+    if (md->sha256.curlen > 56) {
+        while (md->sha256.curlen < 64) {
+            md->sha256.buf[md->sha256.curlen++] = (unsigned char)0;
+        }
+        s_sha256_compress(md, md->sha256.buf);
+        md->sha256.curlen = 0;
     }
 
-    memcpy(((unsigned char*)ctx->wbuf) + pos, sp, len);
-}
-
-/* SHA256 Final padding and digest calculation  */
-
-static sha2_32t  m1[4] =
-{
-    n_u32(00000000), n_u32(ff000000), n_u32(ffff0000), n_u32(ffffff00)
-};
-
-static sha2_32t  b1[4] =
-{
-    n_u32(80000000), n_u32(00800000), n_u32(00008000), n_u32(00000080)
-};
-
-void sha256_end(unsigned char hval[], sha256_ctx ctx[1])
-{   sha2_32t    i = (sha2_32t)(ctx->count[0] & SHA256_MASK);
-
-        bsw_32(ctx->wbuf, (i + 3) >> 2)
-    /* bytes in the buffer are now in an order in which references  */
-    /* to 32-bit words will put bytes with lower addresses into the */
-    /* top of 32 bit words on BOTH big and little endian machines   */
-    
-    /* we now need to mask valid bytes and add the padding which is */
-    /* a single 1 bit and as many zero bits as necessary.           */
-    ctx->wbuf[i >> 2] = (ctx->wbuf[i >> 2] & m1[i & 3]) | b1[i & 3];
-
-    /* we need 9 or more empty positions, one for the padding byte  */
-    /* (above) and eight for the length count.  If there is not     */
-    /* enough space pad and empty the buffer                        */
-    if(i > SHA256_BLOCK_SIZE - 9)
-    {
-        if(i < 60) ctx->wbuf[15] = 0;
-        sha256_compile(ctx);
-        i = 0;
+    /* pad upto 56 bytes of zeroes */
+    while (md->sha256.curlen < 56) {
+        md->sha256.buf[md->sha256.curlen++] = (unsigned char)0;
     }
-    else    /* compute a word index for the empty buffer positions  */
-        i = (i >> 2) + 1;
 
-    while(i < 14) /* and zero pad all but last two positions      */ 
-        ctx->wbuf[i++] = 0;
-    
-    /* the following 32-bit length fields are assembled in the      */
-    /* wrong byte order on little endian machines but this is       */
-    /* corrected later since they are only ever used as 32-bit      */
-    /* word values.                                                 */
+    /* store length */
+    STORE64H(md->sha256.length, md->sha256.buf+56);
+    s_sha256_compress(md, md->sha256.buf);
 
-    ctx->wbuf[14] = (ctx->count[1] << 3) | (ctx->count[0] >> 29);
-    ctx->wbuf[15] = ctx->count[0] << 3;
-
-    sha256_compile(ctx);
-
-    /* extract the hash value as bytes in case the hash buffer is   */
-    /* mislaigned for 32-bit words                                  */
-    for(i = 0; i < SHA256_DIGEST_SIZE; ++i)
-        hval[i] = (unsigned char)(ctx->hash[i >> 2] >> 8 * (~i & 3));
-}
-
-void sha256(unsigned char hval[], const unsigned char data[], unsigned long len) 
-{   sha256_ctx  cx[1];
-    
-    sha256_begin(cx); sha256_hash(data, len, cx); sha256_end(hval, cx);
-}
-
+    /* copy output */
+    for (i = 0; i < 8; i++) {
+        STORE32H(md->sha256.state[i], out+(4*i));
+    }
+#ifdef LTC_CLEAN_STACK
+    zeromem(md, sizeof(hash_state));
 #endif
+    return CRYPT_OK;
+}
 
-#if defined(SHA_2) || defined(SHA_384) || defined(SHA_512)
-
-#define SHA512_MASK (SHA512_BLOCK_SIZE - 1)
-
-#define rotr64(x,n)   (((x) >> n) | ((x) << (64 - n)))
-
-#if !defined(bswap_64)
-#define bswap_64(x) (((sha2_64t)(bswap_32((sha2_32t)(x)))) << 32 | bswap_32((sha2_32t)((x) >> 32)))
-#endif
-
-#if defined(SWAP_BYTES)
-#define bsw_64(p,n)     { int _i = (n); while(_i--) p[_i] = bswap_64(p[_i]); }
-#else
-#define bsw_64(p,n)     
-#endif
-
-/* SHA512 mixing function definitions   */
-
-#define s512_0(x) (rotr64((x), 28) ^ rotr64((x), 34) ^ rotr64((x), 39)) 
-#define s512_1(x) (rotr64((x), 14) ^ rotr64((x), 18) ^ rotr64((x), 41)) 
-#define g512_0(x) (rotr64((x),  1) ^ rotr64((x),  8) ^ ((x) >>  7)) 
-#define g512_1(x) (rotr64((x), 19) ^ rotr64((x), 61) ^ ((x) >>  6)) 
-
-/* rotated SHA512 round definition. Rather than swapping variables as in    */
-/* FIPS-180, different variables are 'rotated' on each round, returning     */
-/* to their starting positions every eight rounds                           */
-
-#define h5(i) ctx->wbuf[i & 15] += \
-    g512_1(ctx->wbuf[(i + 14) & 15]) + ctx->wbuf[(i + 9) & 15] + g512_0(ctx->wbuf[(i + 1) & 15])
-
-#define h5_cycle(i,j)  \
-    v[(7 - i) & 7] += (j ? h5(i) : ctx->wbuf[i & 15]) + k512[i + j] \
-        + s512_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]); \
-    v[(3 - i) & 7] += v[(7 - i) & 7]; \
-    v[(7 - i) & 7] += s512_0(v[(0 - i) & 7]) + maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7])
-
-/* SHA384/SHA512 mixing data    */
-
-const sha2_64t  k512[80] = 
+static int compare_testvector(const unsigned char *a, size_t asize, const unsigned char *b, size_t bsize, const char *name, size_t i)
 {
-    n_u64(428a2f98d728ae22), n_u64(7137449123ef65cd), 
-    n_u64(b5c0fbcfec4d3b2f), n_u64(e9b5dba58189dbbc),
-    n_u64(3956c25bf348b538), n_u64(59f111f1b605d019),
-    n_u64(923f82a4af194f9b), n_u64(ab1c5ed5da6d8118),
-    n_u64(d807aa98a3030242), n_u64(12835b0145706fbe),
-    n_u64(243185be4ee4b28c), n_u64(550c7dc3d5ffb4e2),
-    n_u64(72be5d74f27b896f), n_u64(80deb1fe3b1696b1),
-    n_u64(9bdc06a725c71235), n_u64(c19bf174cf692694),
-    n_u64(e49b69c19ef14ad2), n_u64(efbe4786384f25e3),
-    n_u64(0fc19dc68b8cd5b5), n_u64(240ca1cc77ac9c65),
-    n_u64(2de92c6f592b0275), n_u64(4a7484aa6ea6e483),
-    n_u64(5cb0a9dcbd41fbd4), n_u64(76f988da831153b5),
-    n_u64(983e5152ee66dfab), n_u64(a831c66d2db43210),
-    n_u64(b00327c898fb213f), n_u64(bf597fc7beef0ee4),
-    n_u64(c6e00bf33da88fc2), n_u64(d5a79147930aa725),
-    n_u64(06ca6351e003826f), n_u64(142929670a0e6e70),
-    n_u64(27b70a8546d22ffc), n_u64(2e1b21385c26c926),
-    n_u64(4d2c6dfc5ac42aed), n_u64(53380d139d95b3df),
-    n_u64(650a73548baf63de), n_u64(766a0abb3c77b2a8),
-    n_u64(81c2c92e47edaee6), n_u64(92722c851482353b),
-    n_u64(a2bfe8a14cf10364), n_u64(a81a664bbc423001),
-    n_u64(c24b8b70d0f89791), n_u64(c76c51a30654be30),
-    n_u64(d192e819d6ef5218), n_u64(d69906245565a910),
-    n_u64(f40e35855771202a), n_u64(106aa07032bbd1b8),
-    n_u64(19a4c116b8d2d0c8), n_u64(1e376c085141ab53),
-    n_u64(2748774cdf8eeb99), n_u64(34b0bcb5e19b48a8),
-    n_u64(391c0cb3c5c95a63), n_u64(4ed8aa4ae3418acb),
-    n_u64(5b9cca4f7763e373), n_u64(682e6ff3d6b2b8a3),
-    n_u64(748f82ee5defb2fc), n_u64(78a5636f43172f60),
-    n_u64(84c87814a1f0ab72), n_u64(8cc702081a6439ec),
-    n_u64(90befffa23631e28), n_u64(a4506cebde82bde9),
-    n_u64(bef9a3f7b2c67915), n_u64(c67178f2e372532b),
-    n_u64(ca273eceea26619c), n_u64(d186b8c721c0c207),
-    n_u64(eada7dd6cde0eb1e), n_u64(f57d4f7fee6ed178),
-    n_u64(06f067aa72176fba), n_u64(0a637dc5a2c898a6),
-    n_u64(113f9804bef90dae), n_u64(1b710b35131c471b),
-    n_u64(28db77f523047d84), n_u64(32caab7b40c72493),
-    n_u64(3c9ebe0a15c9bebc), n_u64(431d67c49c100d4c),
-    n_u64(4cc5d4becb3e42b6), n_u64(597f299cfc657e2a),
-    n_u64(5fcb6fab3ad6faec), n_u64(6c44198c4a475817)
-};
-
-/* Compile 64 bytes of hash data into SHA384/SHA512 digest value  */
-
-void sha512_compile(sha512_ctx ctx[1])
-{   sha2_64t    v[8];
-    sha2_32t    j;
-
-    memcpy(v, ctx->hash, 8 * sizeof(sha2_64t));
-
-    for(j = 0; j < 80; j += 16)
-    {
-        h5_cycle( 0, j); h5_cycle( 1, j); h5_cycle( 2, j); h5_cycle( 3, j);
-        h5_cycle( 4, j); h5_cycle( 5, j); h5_cycle( 6, j); h5_cycle( 7, j);
-        h5_cycle( 8, j); h5_cycle( 9, j); h5_cycle(10, j); h5_cycle(11, j);
-        h5_cycle(12, j); h5_cycle(13, j); h5_cycle(14, j); h5_cycle(15, j);
-    }
-
-    ctx->hash[0] += v[0]; ctx->hash[1] += v[1]; ctx->hash[2] += v[2]; ctx->hash[3] += v[3];
-    ctx->hash[4] += v[4]; ctx->hash[5] += v[5]; ctx->hash[6] += v[6]; ctx->hash[7] += v[7];
+    return !(asize == bsize && memcmp(a, b, asize) == 0);
 }
-
-/* Compile 128 bytes of hash data into SHA256 digest value  */
-/* NOTE: this routine assumes that the byte order in the    */
-/* ctx->wbuf[] at this point is in such an order that low   */
-/* address bytes in the ORIGINAL byte stream placed in this */
-/* buffer will now go to the high end of words on BOTH big  */
-/* and little endian systems                                */
-
-void sha512_hash(const unsigned char data[], unsigned long len, sha512_ctx ctx[1])
-{   sha2_32t pos = (sha2_32t)(ctx->count[0] & SHA512_MASK), 
-             space = SHA512_BLOCK_SIZE - pos;
-    const unsigned char *sp = data;
-
-    if((ctx->count[0] += len) < len)
-        ++(ctx->count[1]);
-
-    while(len >= space)     /* tranfer whole blocks while possible  */
-    {
-        memcpy(((unsigned char*)ctx->wbuf) + pos, sp, space);
-        sp += space; len -= space; space = SHA512_BLOCK_SIZE; pos = 0; 
-                bsw_64(ctx->wbuf, SHA512_BLOCK_SIZE >> 3);        
-        sha512_compile(ctx);
-    }
-
-    memcpy(((unsigned char*)ctx->wbuf) + pos, sp, len);
-}
-
-/* SHA384/512 Final padding and digest calculation  */
-
-static sha2_64t  m2[8] =
+/**
+  Self-test the hash
+  @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
+*/
+int  sha256_test(void)
 {
-    n_u64(0000000000000000), n_u64(ff00000000000000), 
-    n_u64(ffff000000000000), n_u64(ffffff0000000000),
-    n_u64(ffffffff00000000), n_u64(ffffffffff000000),
-    n_u64(ffffffffffff0000), n_u64(ffffffffffffff00)
-};
+ #ifndef LTC_TEST
+    return CRYPT_NOP;
+ #else
+  static const struct {
+      const char *msg;
+      unsigned char hash[32];
+  } tests[] = {
+    { "abc",
+      { 0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+        0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad }
+    },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+      { 0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8,
+        0xe5, 0xc0, 0x26, 0x93, 0x0c, 0x3e, 0x60, 0x39,
+        0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
+        0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1 }
+    },
+  };
 
-static sha2_64t  b2[8] =
-{
-    n_u64(8000000000000000), n_u64(0080000000000000), 
-    n_u64(0000800000000000), n_u64(0000008000000000),
-    n_u64(0000000080000000), n_u64(0000000000800000), 
-    n_u64(0000000000008000), n_u64(0000000000000080)
-};
+  int i;
+  unsigned char tmp[32];
+  hash_state md;
 
-static void sha_end(unsigned char hval[], sha512_ctx ctx[1], const unsigned int hlen)
-{   sha2_32t    i = (sha2_32t)(ctx->count[0] & SHA512_MASK);
-
-        bsw_64(ctx->wbuf, (i + 7) >> 3);
-
-    /* bytes in the buffer are now in an order in which references  */
-    /* to 64-bit words will put bytes with lower addresses into the */
-    /* top of 64 bit words on BOTH big and little endian machines   */
-    
-    /* we now need to mask valid bytes and add the padding which is */
-    /* a single 1 bit and as many zero bits as necessary.           */
-    ctx->wbuf[i >> 3] = (ctx->wbuf[i >> 3] & m2[i & 7]) | b2[i & 7];
-
-    /* we need 17 or more empty byte positions, one for the padding */
-    /* byte (above) and sixteen for the length count.  If there is  */
-    /* not enough space pad and empty the buffer                    */
-    if(i > SHA512_BLOCK_SIZE - 17)
-    {
-        if(i < 120) ctx->wbuf[15] = 0;
-        sha512_compile(ctx);
-        i = 0;
-    }
-    else
-        i = (i >> 3) + 1;
-
-    while(i < 14)
-        ctx->wbuf[i++] = 0;
-    
-    /* the following 64-bit length fields are assembled in the      */
-    /* wrong byte order on little endian machines but this is       */
-    /* corrected later since they are only ever used as 64-bit      */
-    /* word values.                                                 */
-
-    ctx->wbuf[14] = (ctx->count[1] << 3) | (ctx->count[0] >> 61);
-    ctx->wbuf[15] = ctx->count[0] << 3;
-
-    sha512_compile(ctx);
-
-    /* extract the hash value as bytes in case the hash buffer is   */
-    /* misaligned for 32-bit words                                  */
-    for(i = 0; i < hlen; ++i)
-        hval[i] = (unsigned char)(ctx->hash[i >> 3] >> 8 * (~i & 7));
+  for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+      sha256_init(&md);
+      sha256_process(&md, (unsigned char*)tests[i].msg, (unsigned long)XSTRLEN(tests[i].msg));
+      sha256_done(&md, tmp);
+      if (compare_testvector(tmp, sizeof(tmp), tests[i].hash, sizeof(tests[i].hash), "SHA256", i)) {
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+  }
+  return CRYPT_OK;
+ #endif
 }
-
-#endif
-
-#if defined(SHA_2) || defined(SHA_384)
-
-/* SHA384 initialisation data   */
-
-const sha2_64t  i384[80] = 
-{
-    n_u64(cbbb9d5dc1059ed8), n_u64(629a292a367cd507),
-    n_u64(9159015a3070dd17), n_u64(152fecd8f70e5939),
-    n_u64(67332667ffc00b31), n_u64(8eb44a8768581511),
-    n_u64(db0c2e0d64f98fa7), n_u64(47b5481dbefa4fa4)
-};
-
-void sha384_begin(sha384_ctx ctx[1])
-{
-    ctx->count[0] = ctx->count[1] = 0;
-    memcpy(ctx->hash, i384, 8 * sizeof(sha2_64t));
-}
-
-void sha384_end(unsigned char hval[], sha384_ctx ctx[1])
-{
-    sha_end(hval, ctx, SHA384_DIGEST_SIZE);
-}
-
-void sha384(unsigned char hval[], const unsigned char data[], unsigned long len)
-{   sha384_ctx  cx[1];
-    
-    sha384_begin(cx); sha384_hash(data, len, cx); sha384_end(hval, cx);
-}
-
-#endif
-
-#if defined(SHA_2) || defined(SHA_512)
-
-/* SHA512 initialisation data   */
-
-const sha2_64t  i512[80] = 
-{
-    n_u64(6a09e667f3bcc908), n_u64(bb67ae8584caa73b),
-    n_u64(3c6ef372fe94f82b), n_u64(a54ff53a5f1d36f1),
-    n_u64(510e527fade682d1), n_u64(9b05688c2b3e6c1f),
-    n_u64(1f83d9abfb41bd6b), n_u64(5be0cd19137e2179)
-};
-
-void sha512_begin(sha512_ctx ctx[1])
-{
-    ctx->count[0] = ctx->count[1] = 0;
-    memcpy(ctx->hash, i512, 8 * sizeof(sha2_64t));
-}
-
-void sha512_end(unsigned char hval[], sha512_ctx ctx[1])
-{
-    sha_end(hval, ctx, SHA512_DIGEST_SIZE);
-}
-
-void sha512(unsigned char hval[], const unsigned char data[], unsigned long len) 
-{   sha512_ctx  cx[1];
-    
-    sha512_begin(cx); sha512_hash(data, len, cx); sha512_end(hval, cx);
-}
-
-#endif
-
-#if defined(SHA_2)
-
-#define CTX_256(x)  ((x)->uu->ctx256)
-#define CTX_384(x)  ((x)->uu->ctx512)
-#define CTX_512(x)  ((x)->uu->ctx512)
-
-/* SHA2 initialisation */
-
-int sha2_begin(unsigned long len, sha2_ctx ctx[1])
-{   unsigned long   l = len;
-    switch(len)
-    {
-        case 256:   l = len >> 3;
-        case  32:   CTX_256(ctx)->count[0] = CTX_256(ctx)->count[1] = 0;
-                    memcpy(CTX_256(ctx)->hash, i256, 32); break;
-        case 384:   l = len >> 3;
-        case  48:   CTX_384(ctx)->count[0] = CTX_384(ctx)->count[1] = 0;
-                    memcpy(CTX_384(ctx)->hash, i384, 64); break;
-        case 512:   l = len >> 3;
-        case  64:   CTX_512(ctx)->count[0] = CTX_512(ctx)->count[1] = 0;
-                    memcpy(CTX_512(ctx)->hash, i512, 64); break;
-        default:    return SHA2_BAD;
-    }
-    
-    ctx->sha2_len = l; return SHA2_GOOD;
-}
-
-void sha2_hash(const unsigned char data[], unsigned long len, sha2_ctx ctx[1])
-{
-    switch(ctx->sha2_len)
-    {
-        case 32: sha256_hash(data, len, CTX_256(ctx)); return;
-        case 48: sha384_hash(data, len, CTX_384(ctx)); return;
-        case 64: sha512_hash(data, len, CTX_512(ctx)); return;
-    }
-}
-
-void sha2_end(unsigned char hval[], sha2_ctx ctx[1])
-{
-    switch(ctx->sha2_len)
-    {
-        case 32: sha256_end(hval, CTX_256(ctx)); return;
-        case 48: sha_end(hval, CTX_384(ctx), SHA384_DIGEST_SIZE); return;
-        case 64: sha_end(hval, CTX_512(ctx), SHA512_DIGEST_SIZE); return;
-    }
-}
-
-int sha2(unsigned char hval[], unsigned long size,
-                                const unsigned char data[], unsigned long len)
-{   sha2_ctx    cx[1];
-
-    if(sha2_begin(size, cx) == SHA2_GOOD)
-    {
-        sha2_hash(data, len, cx); sha2_end(hval, cx); return SHA2_GOOD;
-    }
-    else
-        return SHA2_BAD;
-}
-
-#endif
 
 /* ------------------------------------------------------------------------ */
 /*
  *   MJR additions 
  */
+
+#include <stdarg.h>
+
+#include "t3std.h"
+#include "vmdatasrc.h"
 
 /*
  *   E-Z sha256 - hash a buffer and generate a printable hash string [mjr]
@@ -780,3 +475,4 @@ void sha256_datasrc(char *buf, CVmDataSource *src, unsigned long len)
     *bufp = '\0';
 }
 
+#endif

--- a/tads3/sha2.h
+++ b/tads3/sha2.h
@@ -1,129 +1,36 @@
-/*
- ---------------------------------------------------------------------------
- Copyright (c) 2002, Dr Brian Gladman <brg@gladman.me.uk>, Worcester, UK.
- All rights reserved.
+#ifndef SHA2_H
+#define SHA2_H
 
- LICENSE TERMS
+#include <cstdint>
 
- The free distribution and use of this software in both source and binary 
- form is allowed (with or without changes) provided that:
+#define CRYPT_OK 0
+#define CRYPT_INVALID_ARG 1
+#define CRYPT_NOP 2
+#define CRYPT_HASH_OVERFLOW 3
+#define CRYPT_FAIL_TESTVECTOR 4
 
-   1. distributions of this source code include the above copyright 
-      notice, this list of conditions and the following disclaimer;
+struct sha256_state {
+    std::uint64_t length;
+    std::uint32_t state[8], curlen;
+    unsigned char buf[64];
+};
 
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
+union hash_state {
+    sha256_state sha256;
+};
 
-   3. the copyright holder's name is not used to endorse products 
-      built using this software without specific written permission. 
+int sha256_init(hash_state *md);
+int sha256_process(hash_state *md, const unsigned char *in, unsigned long inlen);
+int sha256_done(hash_state *md, unsigned char *hash);
+int sha256_test();
 
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
- 
- DISCLAIMER
+/* Compatibility with Brian Gladman's SHA-256. */
+using sha256_ctx = hash_state;
+#define sha256_begin(ctx) sha256_init(ctx)
+#define sha256_hash(data, len, ctx) sha256_process((ctx), (data), (len))
+#define sha256_end(hval, ctx) sha256_done((ctx), (hval))
 
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness 
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 30/11/2002
-*/
-
-#ifndef _SHA2_H
-#define _SHA2_H
-
-#include <limits.h>
-
-/*  Defines for suffixes to 32 and 64 bit unsigned numeric values   */
-
-#define sfx_lo(x,y) x##y
-#define sfx_hi(x,y) sfx_lo(x,y)
-#define n_u32(p)    sfx_hi(0x##p,s_u32)
-#define n_u64(p)    sfx_hi(0x##p,s_u64)
-
-/* define an unsigned 32-bit type */
-
-#if UINT_MAX == 0xffffffff
-  typedef   unsigned int     sha2_32t;
-  #define s_u32    u
-#elif ULONG_MAX == 0xffffffff
-  typedef   unsigned long    sha2_32t;
-  #define s_u32   ul
-#else
-#error Please define sha2_32t as an unsigned 32 bit type in sha2.h
-#endif
-
-/* define an unsigned 64-bit type */
-
-#if defined( _MSC_VER )
-  typedef unsigned __int64   sha2_64t;
-  #define s_u64 ui64
-#elif ULONG_MAX == 0xffffffffffffffff
-  typedef unsigned long      sha2_64t;
-  #define s_u64   ul
-#elif ULONG_MAX == 0xffffffff
-  typedef unsigned long long sha2_64t;   /* a somewhat dangerous guess */
-  #define s_u64  ull
-#else
-#error Please define sha2_64t as an unsigned 64 bit type in sha2.h
-#endif
-
-#if defined(__cplusplus)
-extern "C"
-{
-#endif
-
-#define SHA256_DIGEST_SIZE  32
-#define SHA384_DIGEST_SIZE  48
-#define SHA512_DIGEST_SIZE  64
-
-#define SHA256_BLOCK_SIZE   64
-#define SHA384_BLOCK_SIZE  128
-#define SHA512_BLOCK_SIZE  128
-
-#define SHA2_DIGEST_SIZE        SHA256_DIGEST_SIZE
-#define SHA2_MAX_DIGEST_SIZE    SHA512_DIGEST_SIZE
-
-#define SHA2_GOOD   0
-#define SHA2_BAD    1
-
-/* type to hold the SHA256 context                              */
-
-typedef struct
-{   sha2_32t count[2];
-    sha2_32t hash[8];
-    sha2_32t wbuf[16];
-} sha256_ctx;
-
-/* type to hold the SHA384/512 context                  */
-
-typedef struct
-{   sha2_64t count[2];
-    sha2_64t hash[8];
-    sha2_64t wbuf[16];
-} sha512_ctx;
-
-typedef sha512_ctx  sha384_ctx;
-
-/* type to hold a SHA2 context (256/384/512)  */
-
-typedef struct
-{   union
-    {   sha256_ctx  ctx256[1];
-        sha512_ctx  ctx512[1];
-    } uu[1];
-    sha2_32t    sha2_len;
-} sha2_ctx;
-
-void sha256_compile(sha256_ctx ctx[1]);
-void sha512_compile(sha512_ctx ctx[1]);
-
-void sha256_begin(sha256_ctx ctx[1]);
-void sha256_hash(const unsigned char data[], unsigned long len, sha256_ctx ctx[1]);
-void sha256_end(unsigned char hval[], sha256_ctx ctx[1]);
-void sha256(unsigned char hval[], const unsigned char data[], unsigned long len);
+/* TADS-specific functions */
 
 /* 
  *   Generate a printable version of a hash for a given buffer.  'hash' is an
@@ -131,7 +38,7 @@ void sha256(unsigned char hval[], const unsigned char data[], unsigned long len)
  *   to pass in the same buffer for both 'hash' and 'data', as long as it's
  *   big enough (>=65 characters). [mjr] 
  */
-void sha256_ez(char *hash, const char *data, size_t data_len);
+void sha256_ez(char *hash, const char *data, std::size_t data_len);
 
 /*
  *   Generate a printable version of a hash for a given data source. [mjr]
@@ -143,24 +50,5 @@ void sha256_datasrc(char *hash, class CVmDataSource *src, unsigned long len);
  *   subsequent arguments, and hash the result 
  */
 void sha256_ezf(char *hash, const char *fmt, ...);
-
-void sha384_begin(sha384_ctx ctx[1]);
-#define sha384_hash sha512_hash
-void sha384_end(unsigned char hval[], sha384_ctx ctx[1]);
-void sha384(unsigned char hval[], const unsigned char data[], unsigned long len); 
-
-void sha512_begin(sha512_ctx ctx[1]);
-void sha512_hash(const unsigned char data[], unsigned long len, sha512_ctx ctx[1]);
-void sha512_end(unsigned char hval[], sha512_ctx ctx[1]);
-void sha512(unsigned char hval[], const unsigned char data[], unsigned long len); 
-
-int sha2_begin(unsigned long size, sha2_ctx ctx[1]);
-void sha2_hash(const unsigned char data[], unsigned long len, sha2_ctx ctx[1]);
-void sha2_end(unsigned char hval[], sha2_ctx ctx[1]);
-int sha2(unsigned char hval[], unsigned long size, const unsigned char data[], unsigned long len); 
-
-#if defined(__cplusplus)
-}
-#endif
 
 #endif


### PR DESCRIPTION
The original SHA256 implementation requires knowledge of the target machine's endianness, which in turn relies on non-standard headers/macros. The implementation from libtomcrypt is endian-neutral and relies on nothing but standard functions.