### PR TITLE
Include cstddef for std::size_t

### DIFF
--- a/tads3/sha2.h
+++ b/tads3/sha2.h
@@ -1,6 +1,7 @@
 #ifndef SHA2_H
 #define SHA2_H
 
+#include <cstddef>
 #include <cstdint>
 
 #define CRYPT_OK 0


### PR DESCRIPTION
This is required for std::size_t; some platforms expose std::size_t if stdint is included, but that's not guaranteed per the standard, and at least MinGW and Mac don't.