### PR TITLE
Add monospace support for Glk

### DIFF
--- a/glk/osgarglk.h
+++ b/glk/osgarglk.h
@@ -83,6 +83,7 @@ unsigned char *os_fill_buffer (unsigned char *buf, size_t len);
 #define OS_ATTR_HILITE  OS_ATTR_BOLD
 #define OS_ATTR_EM      OS_ATTR_ITALIC
 #define OS_ATTR_STRONG  OS_ATTR_BOLD
+#define OS_ATTR_MONOSP  0x0004
 
 #define OS_DECLARATIVE_TLS
 #define OS_DECL_TLS(t, v) t v

--- a/glk/osgarglk.h
+++ b/glk/osgarglk.h
@@ -83,7 +83,6 @@ unsigned char *os_fill_buffer (unsigned char *buf, size_t len);
 #define OS_ATTR_HILITE  OS_ATTR_BOLD
 #define OS_ATTR_EM      OS_ATTR_ITALIC
 #define OS_ATTR_STRONG  OS_ATTR_BOLD
-#define OS_ATTR_MONOSP  0x0004
 
 #define OS_DECLARATIVE_TLS
 #define OS_DECL_TLS(t, v) t v

--- a/glk/osglk.c
+++ b/glk/osglk.c
@@ -38,6 +38,11 @@
 # define gestalt_GarglkText 0x1100
 #endif
 
+#ifndef gestalt_Stylehints
+// preliminary, likely to change later.
+# define gestalt_Stylehints 0x1101
+#endif
+
 static void redraw_windows(void);
 static void os_status_redraw(void);
 extern void os_banners_redraw(void);
@@ -145,7 +150,7 @@ int os_get_sysinfo(int code, void *param, long *result)
 int os_init(int *argc, char *argv[], const char *prompt,
             char *buf, int bufsiz)
 {
-    if (glk_gestalt(gestalt_GarglkText, 0)) {
+    if (glk_gestalt(gestalt_GarglkText, 0) || glk_gestalt(gestalt_Stylehints, 0)) {
         use_more_text_styling = 1;
         // Use User1 for monospace+bold
         glk_stylehint_set(wintype_TextBuffer, style_User1, stylehint_Proportional, 0);

--- a/glk/osglk.c
+++ b/glk/osglk.c
@@ -408,6 +408,8 @@ void os_set_text_attr(int attr)
         glk_set_style(style_Subheader);
     else if (curattr & OS_ATTR_ITALIC)
         glk_set_style(style_Emphasized);
+    else if (curattr & OS_ATTR_MONOSP)
+        glk_set_style(style_Preformatted);
     else
         glk_set_style(style_Normal);
 }

--- a/glk/osglk.c
+++ b/glk/osglk.c
@@ -158,6 +158,10 @@ int os_init(int *argc, char *argv[], const char *prompt,
         // Use User2 for monospace+italic
         glk_stylehint_set(wintype_TextBuffer, style_User2, stylehint_Proportional, 0);
         glk_stylehint_set(wintype_TextBuffer, style_User2, stylehint_Oblique, 1);
+        // Use Note for monospace+italic+bold
+        glk_stylehint_set(wintype_TextBuffer, style_Note, stylehint_Proportional, 0);
+        glk_stylehint_set(wintype_TextBuffer, style_Note, stylehint_Weight, 1);
+        glk_stylehint_set(wintype_TextBuffer, style_Note, stylehint_Oblique, 1);
     }
 
     mainwin = glk_window_open(0, 0, 0, wintype_TextBuffer, 0);
@@ -413,6 +417,28 @@ void oscls(void)
     glk_window_clear(mainwin);
 }
 
+// mapping of text attributes to Glk styles
+static const glui32 attr_to_style[] = {
+        style_Normal,  // nothing
+        style_Subheader,  // bold
+        style_Emphasized,  // italic
+        style_Alert,  // italic + bold
+        style_Preformatted,  // everything with monospace bit set maps to monospace
+        style_Preformatted,
+        style_Preformatted,
+        style_Preformatted
+};
+static const glui32 attr_to_style_ext[] = {
+        style_Normal,  // nothing
+        style_Subheader,  // bold
+        style_Emphasized,  // italic
+        style_Alert,  // italic + bold
+        style_Preformatted,  // monospace
+        style_User1,  // monospace + bold
+        style_User2,  // monospace + italic
+        style_Note  // monospace + bold + italic
+};
+
 /* ------------------------------------------------------------------------ */
 /*
  *   Set text attributes.  Text subsequently displayed through os_print() and
@@ -423,21 +449,14 @@ void oscls(void)
  */
 void os_set_text_attr(int attr)
 {
+    // If anyone adds more style attributes in the future, our array lookup
+    // will blow up, so...
+    assert(attr < 8);
     curattr = attr;
-    if (use_more_text_styling && (curattr & OS_ATTR_MONOSP) && (curattr & OS_ATTR_BOLD))
-        glk_set_style(style_User1);
-    else if (use_more_text_styling && (curattr & OS_ATTR_MONOSP) && (curattr & OS_ATTR_ITALIC))
-        glk_set_style(style_User2);
-    else if (curattr & OS_ATTR_MONOSP)
-        glk_set_style(style_Preformatted);
-    else if (curattr & OS_ATTR_BOLD && curattr & OS_ATTR_ITALIC)
-        glk_set_style(style_Alert);
-    else if (curattr & OS_ATTR_BOLD)
-        glk_set_style(style_Subheader);
-    else if (curattr & OS_ATTR_ITALIC)
-        glk_set_style(style_Emphasized);
+    if (use_more_text_styling)
+        glk_set_style(attr_to_style_ext[curattr]);
     else
-        glk_set_style(style_Normal);
+        glk_set_style(attr_to_style[curattr]);
 }
 
 /*

--- a/tads2/osifc.h
+++ b/tads2/osifc.h
@@ -2932,6 +2932,12 @@ void os_set_text_attr(int attr);
 # define OS_ATTR_STRONG  0
 #endif
 
+/* Monospaced text (HTML <tt> attribute - by default, this has no effect.
+ * (Introduced for the Glk port  -- AW 2023-01-20) */
+#ifndef OS_ATTR_MONOSP
+# define OS_ATTR_MONOSP  0
+#endif
+
 
 /* ------------------------------------------------------------------------ */
 /*

--- a/tads2/osifc.h
+++ b/tads2/osifc.h
@@ -2899,6 +2899,10 @@ void os_set_text_attr(int attr);
 /* attribute code: italic */
 #define OS_ATTR_ITALIC   0x0002
 
+/* attribute code: monospace
+ * (Introduced for the Glk port  -- AW 2023-01-20) */
+#define OS_ATTR_MONOSP   0x0004
+
 /*
  *   Abstract attribute codes.  Each platform can choose a custom rendering
  *   for these by #defining them before this point, in the OS-specific header
@@ -2930,12 +2934,6 @@ void os_set_text_attr(int attr);
 /* HTML <strong> attribute - by default, this has no effect */
 #ifndef OS_ATTR_STRONG
 # define OS_ATTR_STRONG  0
-#endif
-
-/* Monospaced text (HTML <tt> attribute - by default, this has no effect.
- * (Introduced for the Glk port  -- AW 2023-01-20) */
-#ifndef OS_ATTR_MONOSP
-# define OS_ATTR_MONOSP  0
 #endif
 
 

--- a/tads2/output.c
+++ b/tads2/output.c
@@ -2656,16 +2656,20 @@ static int outformatlen_stream(out_stream_info *stream,
                 }
                 else if (!stricmp(tagbuf, "pre"))
                 {
-                    /* count the nesting level if starting PRE mode */
-                    if (!is_end_tag)
+                    if (!is_end_tag) {
+                        /* entering PRE mode: count nesting level, send line break, select monospace font */
                         stream->html_pre_level += 1;
-
-                    /* surround the PRE block with line breaks */
-                    outblank_stream(stream);
-
-                    /* count the nesting level if ending PRE mode */
-                    if (is_end_tag && stream->html_pre_level != 0)
+                        outblank_stream(stream);
+                        stream->cur_attr |= OS_ATTR_MONOSP;
+                    } else if (stream->html_pre_level > 0) {
+                        /* ending PRE mode: reduce nesting level */
                         stream->html_pre_level -= 1;
+                        if (stream->html_pre_level == 0)
+                            /* get rid of monospace font if we're completely out of PRE mode */
+                            stream->cur_attr &= (~OS_ATTR_MONOSP);
+                        /* send line break */
+                        outblank_stream(stream);
+                    }
                 }
 
                 /* suppress everything up to the next '>' */

--- a/tads2/output.c
+++ b/tads2/output.c
@@ -2470,7 +2470,8 @@ static int outformatlen_stream(out_stream_info *stream,
                 else if (!stricmp(tagbuf, "b")
                          || !stricmp(tagbuf, "i")
                          || !stricmp(tagbuf, "em")
-                         || !stricmp(tagbuf, "strong"))
+                         || !stricmp(tagbuf, "strong")
+                         || !stricmp(tagbuf, "tt"))
                 {
                     int attr;
                     
@@ -2495,6 +2496,11 @@ static int outformatlen_stream(out_stream_info *stream,
                     case 's':
                     case 'S':
                         attr = OS_ATTR_STRONG;
+                        break;
+
+                    case 't':
+                    case 'T':
+                        attr = OS_ATTR_MONOSP;
                         break;
                     }
                     

--- a/tads3/vmconhmp.cpp
+++ b/tads3/vmconhmp.cpp
@@ -1458,7 +1458,8 @@ wchar_t CVmFormatter::parse_html_markup(VMG_ wchar_t c,
         else if (CVmCaseFoldStr::wstreq(tagbuf, L"b")
                  || CVmCaseFoldStr::wstreq(tagbuf, L"i")
                  || CVmCaseFoldStr::wstreq(tagbuf, L"em")
-                 || CVmCaseFoldStr::wstreq(tagbuf, L"strong"))
+                 || CVmCaseFoldStr::wstreq(tagbuf, L"strong")
+                 || CVmCaseFoldStr::wstreq(tagbuf, L"tt"))
         {
             /* suppress in ignore mode */
             if (!html_in_ignore_)
@@ -1492,6 +1493,11 @@ wchar_t CVmFormatter::parse_html_markup(VMG_ wchar_t c,
                     case 's':
                     case 'S':
                         attr = OS_ATTR_STRONG;
+                        break;
+
+                    case 't':
+                    case 'T':
+                        attr = OS_ATTR_MONOSP;
                         break;
                     }
 

--- a/tads3/vmconhmp.cpp
+++ b/tads3/vmconhmp.cpp
@@ -1711,16 +1711,16 @@ wchar_t CVmFormatter::parse_html_markup(VMG_ wchar_t c,
         }
         else if (CVmCaseFoldStr::wstreq(tagbuf, L"pre"))
         {
-            /* count the nesting level if starting PRE mode */
-            if (!is_end_tag)
+            if (!is_end_tag) {
                 ++html_pre_level_;
-
-            /* surround the PRE block with blank lines */
-            write_blank_line(vmg0_);
-
-            /* count the nesting level if ending PRE mode */
-            if (is_end_tag && html_pre_level_ != 0)
+                write_blank_line(vmg0_);
+                push_color();
+                cur_color_.attr |= OS_ATTR_MONOSP;
+            } else if (html_pre_level_ > 0){
                 --html_pre_level_;
+                pop_color();
+                write_blank_line(vmg0_);
+            }
         }
 
         /* suppress everything up to the next '>' */


### PR DESCRIPTION
This adds support for the `<tt>` formatting tag for (Gar)Glk interpreters