### PR TITLE
Use Gargoyle extension for determining banner size

### DIFF
--- a/glk/osglkban.c
+++ b/glk/osglkban.c
@@ -28,10 +28,6 @@
 #include "os.h"
 #include "glk.h"
 
-#ifdef GARGLK
-#include "garglk.h"                 /* for-size to-contents hack */
-#endif /* GARGLK */
-
 typedef struct os_banner_s *osbanid_t;
 typedef struct banner_contents_s *contentid_t;
 
@@ -548,11 +544,7 @@ void os_banner_size_to_contents(void *banner_handle)
 #ifdef GARGLK
     if (banner->type == wintype_TextBuffer)
     {
-        winid_t win = banner->win;
-        window_textbuffer_t *dwin = win->data;
-        int size = dwin->scrollmax;
-        if (dwin->numchars)
-            size ++;
+        int size = garglk_tads_os_banner_size(banner->win);
         os_banner_set_size(banner, size, OS_BANNER_SIZE_ABS, 0);
     }
 #endif /* GARGLK */


### PR DESCRIPTION
TADS used to reach into Gargoyle's internal data structures for this, but that was always fragile, and since garglk.h is now C++, it can no longer be included in a C program. A custom extension was made for TADS which does exactly what this code did, but with a stable C API.